### PR TITLE
Initial

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,7 @@
 {
   "name": "ProjectNemo",
-  "displayName": "ProjectNemo"
+  "displayName": "ProjectNemo",
+  "android": {
+    "softwareKeyboardLayoutMode": "pan",
+    }
 }

--- a/src/navigation/TabNavigation.js
+++ b/src/navigation/TabNavigation.js
@@ -35,6 +35,12 @@ export const AppNavigator = () => {
       screenOptions={({route}) => ({
         tabBarActiveTintColor: colors.primary,
         tabBarInactiveTintColor: colors.primaryText,
+        // tabBarLabelPosition required to keep labels below icons otherwise they may shift to the
+        // side after a certain height limitation.
+        tabBarLabelPosition: 'below-icon',
+        // tabBarHideOnKeyboard is jank af on Android but putting here for discussion.
+        // https://github.com/react-navigation/react-navigation/issues/6700#issuecomment-547084964
+        tabBarHideOnKeyboard: 'true',
         tabBarLabelStyle: {
           fontFamily: 'NotoSans-Regular',
           fontSize: 12,


### PR DESCRIPTION
Icon & labels on tab bar do not move or change if the height of the screen changes (due to keyboard). Labels stay below icons in tab.